### PR TITLE
TimeCreated Output format is changed from 12-hour to 24-hour  and add timezone

### DIFF
--- a/Soap/Read-WinEvent.ps1
+++ b/Soap/Read-WinEvent.ps1
@@ -18,7 +18,7 @@ filter Read-WinEvent {
   ForEach-Object {
       $Field = $_
       if ($Field -eq 'TimeCreated') {
-          $WinEvent.$Field = Get-Date -Format 'yyyy-MM-dd hh:mm:ss' $SystemData[$Field].SystemTime
+          $WinEvent.$Field = Get-Date -Format 'yyyy-MM-dd HH:mm:ss K' $SystemData[$Field].SystemTime
       } elseif ($SystemData[$Field].'#text') {
           $WinEvent.$Field = $SystemData[$Field].'#text'
       } else {


### PR DESCRIPTION
Thank you very much for open-sourcing this project. This tool has been incredibly helpful for our team. However, when using TimeCreated from Windows logs, the 12-hour format makes it difficult for us to pinpoint the exact time and corresponding time zone. Therefore, we would like to request an enhancement to address this issue. Thank you!